### PR TITLE
Impl end ?> tag matcher based on syntactic structure

### DIFF
--- a/poly-php.el
+++ b/poly-php.el
@@ -29,23 +29,12 @@
 
 ;;; Code:
 (require 'polymode)
+(require 'php)
 (require 'php-mode)
-
-(defvar poly-php-ignore-php-close-tag-faces
-  '(php-string
-    font-lock-doc-face
-    font-lock-comment-face
-    font-lock-string-face))
 
 (defconst poly-php--re-tag-tail-matcher
   (eval-when-compile
     (rx "?>")))
-
-(defsubst poly-php--at-not-literal (point)
-  "Return T when `POINT' not at out of string literal or comment."
-  (let ((face (plist-get (text-properties-at point) 'face)))
-    (null (memq (if (consp face) (car face) face)
-                poly-php-ignore-php-close-tag-faces))))
 
 (defun poly-php--tag-tail-matcher (ahead)
   "Matcher for tail of PHP block."
@@ -54,7 +43,7 @@
           found matched)
       (while (and (not found)
                   (setq matched (funcall re-search poly-php--re-tag-tail-matcher nil t)))
-        (when (and matched (poly-php--at-not-literal (point)))
+        (when (and matched (not (php-in-string-or-comment-p)))
           (setq found (cons (match-beginning 0) (match-end 0)))))
       found)))
 

--- a/poly-php.el
+++ b/poly-php.el
@@ -31,14 +31,40 @@
 (require 'polymode)
 (require 'php-mode)
 
+(defvar poly-php-ignore-php-close-tag-faces
+  '(php-string
+    font-lock-doc-face
+    font-lock-comment-face
+    font-lock-string-face))
+
+(defconst poly-php--re-tag-tail-matcher
+  (eval-when-compile
+    (rx "?>")))
+
+(defsubst poly-php--at-not-literal (point)
+  "Return T when `POINT' not at out of string literal or comment."
+  (let ((face (plist-get (text-properties-at point) 'face)))
+    (null (memq (if (consp face) (car face) face)
+                poly-php-ignore-php-close-tag-faces))))
+
+(defun poly-php--tag-tail-matcher (ahead)
+  "Matcher for tail of PHP block."
+  (save-excursion
+    (let ((re-search (if (< ahead 0) #'re-search-backward #'re-search-forward))
+          found matched)
+      (while (and (not found)
+                  (setq matched (funcall re-search poly-php--re-tag-tail-matcher nil t)))
+        (when (and matched (poly-php--at-not-literal (point)))
+          (setq found (cons (match-beginning 0) (match-end 0)))))
+      found)))
+
 (define-innermode php-innermode
   :mode 'php-mode
   :head-matcher (eval-when-compile
                   (rx (or (: "<?php" word-end)
                           (: "<?=")
                           (: "<?" (or " " "\t" "\n" "\r")))))
-  :tail-matcher (eval-when-compile
-                  (rx "?>"))
+  :tail-matcher #'poly-php--tag-tail-matcher
   :head-mode 'body
   :tail-mode 'body)
 


### PR DESCRIPTION
refs #1 
However, this implementation has two problems.

 1. PHP block is focused and chunks in the correct range are not created until it is changed.
 2. This matcher may trigger font-lock runtime errors.

<img width="599" alt="スクリーンショット 2019-05-26 11 55 31" src="https://user-images.githubusercontent.com/822086/58376900-036da600-7fb0-11e9-8763-bb77e5b1975a.png">

```
Debugger entered--Lisp error: (error "Selecting deleted buffer")
  #f(compiled-function () #<bytecode 0x400da203>)()
  font-lock-default-fontify-region(37 107 nil)
  c-font-lock-fontify-region(37 40 nil)
  #f(compiled-function (beg end &optional loudly) #<bytecode 0x400d9fbf>)(37 40)
  apply(#f(compiled-function (beg end &optional loudly) #<bytecode 0x400d9fbf>) (37 40))
  polymode-inhibit-during-initialization(#f(compiled-function (beg end &optional loudly) #<bytecode 0x400d9fbf>) 37 40)
  apply(polymode-inhibit-during-initialization #f(compiled-function (beg end &optional loudly) #<bytecode 0x400d9fbf>) (37 40))
  font-lock-fontify-region(37 40)
  #f(compiled-function (fun) #<bytecode 0x44a776f1>)(font-lock-fontify-region)
  run-hook-wrapped(#f(compiled-function (fun) #<bytecode 0x44a776f1>) font-lock-fontify-region)
  jit-lock--run-functions(37 40)
  #f(compiled-function (span) #<bytecode 0x44a73af1>)((head 37 40 #<pm-inner-chunkmode php:>))
  pm-map-over-spans(#f(compiled-function (span) #<bytecode 0x44a73af1>) 37 106)
  poly-lock-fontify-now(37 106)
  poly-lock-function(37)
  redisplay_internal\ \(C\ function\)()
```